### PR TITLE
Text inline widgets, TextSpan rework

### DIFF
--- a/packages/@vue/cli-service/generator/index.js
+++ b/packages/@vue/cli-service/generator/index.js
@@ -21,8 +21,7 @@ module.exports = (api, options) => {
     },
     browserslist: [
       '> 1%',
-      'last 2 versions',
-      'not ie <= 8'
+      'last 2 versions'
     ]
   })
 

--- a/packages/@vue/cli-ui-addon-widgets/.browserslistrc
+++ b/packages/@vue/cli-ui-addon-widgets/.browserslistrc
@@ -1,3 +1,2 @@
 > 1%
 last 2 versions
-not ie <= 8


### PR DESCRIPTION
The `not ie <= 8` rule in the browserlist is redundant. `ie <= 8` browsers aren't added by `> 1%` nor `last 2 versions`