### PR TITLE
Add macosPrefix to the pubspec s

### DIFF
--- a/scripts/patchChromedriver.js
+++ b/scripts/patchChromedriver.js
@@ -1,10 +1,10 @@
-// Appveyor current only ships Chrome 65
+// Appveyor current only ships Chrome 72
 // which is no longer supported by the latest version of Chromedriver.
 
 const fs = require('fs')
 const path = require('path')
 const pkg = require('../package.json')
 
-pkg.resolutions.chromedriver = '2.38.0'
+pkg.resolutions.chromedriver = '2.45.0'
 
 fs.writeFileSync(path.resolve(__dirname, '../package.json'), JSON.stringify(pkg, null, 2))


### PR DESCRIPTION
Their Chrome version has been updated.
See https://www.appveyor.com/updates/2019/02/11/