### PR TITLE
Does K8s have plans

### DIFF
--- a/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
+++ b/packages/@vue/cli-service/lib/commands/build/resolveWcEntry.js
@@ -16,12 +16,12 @@ const hyphenate = str => {
  * @param {string} prefix The prefix for the component library
  * @param {string} component The component name for single entry builds, component file for multi-entry builds
  * @param {string} file The file for the component
- * @param {boolean} async Whether to load component async or not
+ * @param {boolean} isAsync Whether to load component async or not
  */
-const createElement = (prefix, component, file, async) => {
+const createElement = (prefix, component, file, isAsync) => {
   const { camelName, kebabName } = exports.fileToComponentName(prefix, component)
 
-  return async
+  return isAsync
     ? `window.customElements.define('${kebabName}', wrap(Vue, () => import('~root/${file}?shadow')))\n`
     : `import ${camelName} from '~root/${file}?shadow'\n` +
         `window.customElements.define('${kebabName}', wrap(Vue, ${camelName}))\n`
@@ -38,12 +38,12 @@ exports.fileToComponentName = (prefix, file) => {
   }
 }
 
-exports.resolveEntry = (prefix, libName, files, async) => {
+exports.resolveEntry = (prefix, libName, files, isAsync) => {
   const filePath = path.resolve(__dirname, 'entry-wc.js')
   const elements =
     prefix === ''
       ? [createElement('', libName, files[0])]
-      : files.map(file => createElement(prefix, file, file, async)).join('\n')
+      : files.map(file => createElement(prefix, file, file, isAsync)).join('\n')
 
   const content = `
 import './setPublicPath'


### PR DESCRIPTION
`async` is a javascript keyword, so I suggest this variable name will be less prone to error and confusing.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Other information:**
